### PR TITLE
Additions to puppet-rhsm

### DIFF
--- a/files/facter
+++ b/files/facter
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if ! subscription-manager list | grep -qi subscribed; then
+  echo "subscribed=false"
+else
+  echo "subscribed=true"
+fi

--- a/manifests/facter.pp
+++ b/manifests/facter.pp
@@ -1,0 +1,10 @@
+class rhsm::facter {
+#Custom facter to see if server has subscription to rhsm
+  file { "/etc/puppetlabs/facter/facts.d/rhsm_subscribed.sh":
+    source             => "puppet:///modules/rhsm/facter",
+    mode               => "0700",
+    owner              => "root",
+    group              => "root",
+    }
+
+}


### PR DESCRIPTION
Switched to single quotes for username and password fixing the registration issue for RHEL 6.6 servers. Added facter to test if system is already subscribed to keep systems from being re-registered on subsequent runs